### PR TITLE
Change Profile Info to Use Context Instead of Prop

### DIFF
--- a/src/scenes/dashboard/DashboardPage.tsx
+++ b/src/scenes/dashboard/DashboardPage.tsx
@@ -60,10 +60,7 @@ const DashboardPage: React.FC<DashboardPageProps> = ({}) => {
     <div id="dashboard">
       <DashboardNav />
       <Routes>
-        <Route
-          path="/preferences"
-          element={<UserProfileForm user={userInformation} />}
-        />
+        <Route path="/preferences" element={<UserProfileForm />} />
         <Route
           path="/edit_record"
           element={<OneRepMax user={userInformation} />}

--- a/src/scenes/dashboard/UserProfileForm.tsx
+++ b/src/scenes/dashboard/UserProfileForm.tsx
@@ -1,45 +1,49 @@
-import { ChangeEvent, useState, useEffect } from "react";
+import { ChangeEvent, useEffect } from "react";
 import { toast } from "react-toastify";
 import Button from "../../components/Button";
 import axios from "axios";
-import { User } from "../../contexts/UserContext";
 
-interface UserProfileFormProps {
-  user: User;
-}
+import { useUser, useUserUpdate, User } from "../../contexts/UserContext";
 
-const UserProfileForm: React.FC<UserProfileFormProps> = ({ user }) => {
-  const [userInformation, setUserInformation] = useState<Partial<User>>({
-    firstName: "",
-    lastName: "",
-    email: "",
-    gender: "",
-    bodyweight: "",
-  });
+interface UserProfileFormProps {}
+
+const UserProfileForm: React.FC<UserProfileFormProps> = () => {
+  const userInformation = useUser();
+  const setUserInformation = useUserUpdate();
+
+  if (!userInformation) {
+    return <div>Loading...</div>;
+  }
 
   const { firstName, lastName, email, gender, bodyweight } = userInformation;
 
   useEffect(() => {
-    const { firstName, lastName, email, gender, bodyweight } = user;
-    setUserInformation({ firstName, lastName, email, gender, bodyweight });
-  }, [user]);
+    const { firstName, lastName, email, gender, bodyweight } = userInformation;
+    setUserInformation({
+      firstName,
+      lastName,
+      email,
+      gender,
+      bodyweight,
+    } as User);
+  }, []);
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
 
     const parsedValue = name === "bodyweight" ? parseInt(value, 10) : value;
 
-    setUserInformation((prevUserInformation) => ({
-      ...prevUserInformation,
+    setUserInformation({
+      ...userInformation,
       [e.target.name]: parsedValue,
-    }));
+    });
   };
 
   const handleSelectChange = (name: string, value: string) => {
-    setUserInformation((prevUserInformation) => ({
-      ...prevUserInformation,
+    setUserInformation({
+      ...userInformation,
       [name]: value,
-    }));
+    });
   };
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {


### PR DESCRIPTION
Resolves #17 

Change Profile info to use context instead of prop, as dashboard passes in user object, user object state is not modified, needing a full refresh for information to be grabbed again. Using context fixes this as state is changed within context.